### PR TITLE
STM32 support for custom I2C pins

### DIFF
--- a/src/MT6701_I2C.cpp
+++ b/src/MT6701_I2C.cpp
@@ -85,6 +85,14 @@ void MT6701I2C::begin(int8_t _sda_pin, int8_t _scl_pin) {
   _wire_->begin(_sda_pin, _scl_pin);
 }
 #endif
+
+#if defined(ARDUINO_ARCH_STM32)
+void MT6701I2C::begin(int8_t _sda_pin, int8_t _scl_pin) {
+  _wire_->setSDA(_sda_pin);
+  _wire_->setSCL(_scl_pin);
+  _wire_->begin();
+}
+#endif
 /* 
  * @brief: настройка произвольной частоты шины I2C (по умолчанию 400кГц)
  * @note: использовать, если частота шины меняется из-за разных устройств

--- a/src/MT6701_I2C.h
+++ b/src/MT6701_I2C.h
@@ -144,7 +144,7 @@ class MT6701I2C {
     MT6701I2C(TwoWire* _twi); // Конструктор с использованием только интерфейса I2C
 
     void begin(void); // Вызов Wire.begin()
-#if defined(ESP8266) || defined(ESP32)
+#if defined(ESP8266) || defined(ESP32) || defined(ARDUINO_ARCH_STM32)
     void begin(int8_t _sda_pin, int8_t _scl_pin); // Вызов Wire.begin(SDA, SCL) с указанием выводов
 #endif
     void setClock(uint32_t _clock = MT6701_I2C_CLOCK_400KHZ); // Настройка частоты на 100кГц, 400кГц, 1МГц, или пользовательское значение (по умолчанию 400кГц)


### PR DESCRIPTION
Hi there

While using this library, I had to specify which pins I want to use for I2C communication on my STM32 Nucleo board. 
The changes use Arduino wide defines for the STM32 platform. The user can then just use the overloaded begin function with the specified pins. 